### PR TITLE
Template Upsert + Display Refactor + Error Handler

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-build = { version = "1.0.2", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.0.2", features = ["api-all"] }
-dropbox-sdk = { version = "0.15.0", features = ["default_client"] }
+dropbox-sdk = { version = "0.15.0", features = ["default_client", "dbx_check", "dbx_file_properties", "dbx_files"] }
 # TODO: There is a way to cut down on compile time for dropbox sdk by only specifying the features it needs (see the docs)
 
 [features]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,11 +3,37 @@
     windows_subsystem = "windows"
 )]
 
-use std::sync::Mutex;
+use std::{fs, sync::Mutex};
 
 use dropbox_sdk::oauth2;
 
 const APPKEY: &str = "z4c46xuhvi38jhh";
+
+#[derive(serde::Serialize)]
+struct StringFromErr(String);
+impl<E> From<E> for StringFromErr
+where
+    E: std::error::Error,
+{
+    fn from(e: E) -> Self {
+        Self(format!("{}", e))
+    }
+}
+
+#[derive(serde::Deserialize, std::fmt::Debug)]
+struct Template {
+    /// Display name for the template. Template names can be up to 256 bytes.
+    pub name: String,
+    /// Description for the template. Template descriptions can be up to 1024 bytes.
+    pub description: String,
+    /// Definitions of the property fields associated with this template. There can be up to 32
+    /// properties in a single template.
+    pub fields: Vec<dropbox_sdk::file_properties::PropertyFieldTemplate>,
+}
+
+struct AppInfo {
+    template_id: Option<String>,
+}
 
 //A state to manage what stage of authentication the user is at as well as store any corresponding data for each
 enum AuthState {
@@ -41,34 +67,74 @@ fn get_auth_url(auth: tauri::State<Mutex<AuthState>>) -> String {
 
 //Using the authorization code, complete the authentication process
 #[tauri::command]
-fn finalize_auth(auth: tauri::State<Mutex<AuthState>>, code: &str) {
-    let auth_type = if let AuthState::AuthInProgress(auth_struct) = &*(auth).lock().unwrap() {
-        auth_struct.auth_type.clone()
+fn finalize_auth(auth: tauri::State<Mutex<AuthState>>, code: &str) -> Result<(), StringFromErr> {
+    let mut lock = auth.lock().unwrap();
+    let auth_type = if let AuthState::AuthInProgress(auth_struct) = &*lock {
+        &auth_struct.auth_type
     } else {
-        panic!("Something went wrong") //TODO: change this such that it just tells the user that something went wrong
+        return Err(StringFromErr("There was an error accessing the authentication type (OAuth2 not initalized / Auth State incorrect)".to_string()));
     };
 
     let client = dropbox_sdk::default_client::UserAuthDefaultClient::new(
         oauth2::Authorization::from_auth_code(
             APPKEY.to_string(),
-            auth_type,
+            auth_type.clone(),
             code.to_string(),
             None,
         ),
     );
 
-    //This is a test to prove that the authentication is working
-    let result = dropbox_sdk::files::list_folder(
-        &client,
-        &dropbox_sdk::files::ListFolderArg::new("".to_string()),
-    )
-    .expect("There was an error querying dropbox")
-    .expect("There was an error getting the folders");
+    //make a test call to ensure the client was built correctly
+    dropbox_sdk::files::list_folder(&client, &dropbox_sdk::files::ListFolderArg::new("".into()))??;
 
-    println!("Folder contents: {:?}", result.entries);
-    //End test code
+    *lock = AuthState::Authenticated(AuthInfo { client });
 
-    *auth.lock().unwrap() = AuthState::Authenticated(AuthInfo { client });
+    Ok(())
+}
+
+//Checks the app's registered templates to see if a template exists.
+//-If no template exists, it creates a new one
+//-If the template exists, it updates it with the most recent `template.json` file configuration
+#[tauri::command]
+fn upsert_template(
+    auth: tauri::State<Mutex<AuthState>>,
+    app_info: tauri::State<Mutex<AppInfo>>,
+) -> Result<(), StringFromErr> {
+    use dropbox_sdk::file_properties;
+
+    let guard = auth.lock().unwrap();
+    let info = if let AuthState::Authenticated(info) = &*guard {
+        info
+    } else {
+        return Err(StringFromErr("There was an error accessing the authentication info (AuthInfo not initalized / Auth State incorrect)".into()));
+    };
+
+    let templates = file_properties::templates_list_for_user(&info.client)??;
+
+    let file = fs::read_to_string("template.json")?;
+    let template: Template = serde_json::from_str(file.as_str())?;
+    println!(
+        "The list of templates that have been generated: {:?}",
+        &templates
+    );
+    if templates.template_ids.is_empty() {
+        //Create the template from the JSON fill
+        let arg = file_properties::AddTemplateArg::new(
+            template.name,
+            template.description,
+            template.fields,
+        );
+        let result = file_properties::templates_add_for_user(&info.client, &arg)??;
+        app_info.lock().unwrap().template_id = Some(result.template_id);
+    } else {
+        //Update the template from the JSON file
+        let arg = file_properties::UpdateTemplateArg::new(templates.template_ids[0].clone())
+            .with_add_fields(template.fields);
+        file_properties::templates_update_for_user(&info.client, &arg)??;
+        app_info.lock().unwrap().template_id = Some(templates.template_ids[0].clone());
+    }
+
+    Ok(())
 }
 
 fn main() {
@@ -83,7 +149,12 @@ fn main() {
             tauri::Menu::default()
         })
         .manage(Mutex::new(state))
-        .invoke_handler(tauri::generate_handler![get_auth_url, finalize_auth,])
+        .manage(Mutex::new(AppInfo { template_id: None }))
+        .invoke_handler(tauri::generate_handler![
+            get_auth_url,
+            finalize_auth,
+            upsert_template,
+        ])
         .run(context)
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,12 +22,12 @@ where
 
 #[derive(serde::Deserialize, std::fmt::Debug)]
 struct Template {
-    /// Display name for the template. Template names can be up to 256 bytes.
+    // Display name for the template. Template names can be up to 256 bytes.
     pub name: String,
-    /// Description for the template. Template descriptions can be up to 1024 bytes.
+    // Description for the template. Template descriptions can be up to 1024 bytes.
     pub description: String,
-    /// Definitions of the property fields associated with this template. There can be up to 32
-    /// properties in a single template.
+    // Definitions of the property fields associated with this template. There can be up to 32
+    // properties in a single template.
     pub fields: Vec<dropbox_sdk::file_properties::PropertyFieldTemplate>,
 }
 

--- a/src-tauri/template.json
+++ b/src-tauri/template.json
@@ -1,0 +1,20 @@
+{
+    "name": "OPMtemplate",
+    "description": "A template for the OpenPaperMatter project.",
+    "fields": [
+        {
+            "name": "Author",
+            "description": "",
+            "type": {
+                ".tag": "string"
+            }
+        },
+        {
+            "name": "Date published",
+            "description": "",
+            "type": {
+                ".tag": "string"
+            }
+        }
+    ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,32 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import logo from './logo.svg'
 import './App.css'
 import { invoke } from '@tauri-apps/api'
 
-function App() {
+interface BaseParams {
+  setState: (state: number) => void,
+}
+const AuthPage = (props: BaseParams) => {
 
-  invoke('get_auth_url').then((url) => {
-    document.getElementById("auth_url")?.setAttribute("href", String(url));
-  })
+  const [authUrl, setAuthUrl] = useState("");
+
+  //We need to wrap this in useEffect so it only happens on first render, otherwise, on state change, react would rerender again and loop
+  useEffect(() => {
+    invoke('get_auth_url').then((url) => {
+      setAuthUrl(String(url));
+    })
+  }, []);
+
+
   return (
-    <div className="App">
+    < div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>
           <a
             id="auth_url"
             className='auth_url'
-            href=""
+            href={authUrl}
             target="_blank"
           >
             Obtain Auth Key
@@ -25,16 +35,54 @@ function App() {
         <p>
           <input type='text' id="auth-code" placeholder='Paste authentication code here' />
           <button onClick={() => {
-            let code = (document.getElementById("auth-code") as HTMLInputElement).value;
-            invoke('finalize_auth', { code });
+            let code: string = (document.getElementById("auth-code") as HTMLInputElement).value;
+            invoke('finalize_auth', { code })
+              .catch((err) => console.error(err))
+              .then(() => props.setState(1));
           }}>Submit</button>
         </p>
         <p>
           Edit <code>App.tsx</code> and save to test HMR updates.
         </p>
       </header>
+    </div >
+  )
+};
+
+const MainPage = (props: BaseParams) => {
+
+  useEffect(() => {
+    invoke('upsert_template').catch((err) => { console.error(err) });
+  }, []);
+
+  return (
+    < div className="App" >
+      <div className='nav'>
+      </div>
     </div>
   )
+};
+
+const ErrorPage = () => {
+  return (
+    <div>Error, this page occurs when the app attemps to swap to a page that doesn't exist. Please open an issue if you ever see this page</div>
+  )
+}
+
+function App() {
+
+  const [state, setState] = useState(0);
+
+  //depending on the state of the app (set through an enum, the app will display a specific page)
+  switch (state) {
+    case 0:
+      return <AuthPage setState={setState} />;
+    case 1:
+      return <MainPage setState={setState} />;
+    default:
+      return <ErrorPage />
+  }
+
 }
 
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,15 @@ import logo from './logo.svg'
 import './App.css'
 import { invoke } from '@tauri-apps/api'
 
+
+const Pages = {
+  AuthPage: 'AuthPage',
+  MainPage: 'MainPage',
+  ErrorPage: 'ErrorPage',
+}
+
 interface BaseParams {
-  setState: (state: number) => void,
+  setState: (state: string) => void,
 }
 const AuthPage = (props: BaseParams) => {
 
@@ -38,7 +45,7 @@ const AuthPage = (props: BaseParams) => {
             let code: string = (document.getElementById("auth-code") as HTMLInputElement).value;
             invoke('finalize_auth', { code })
               .catch((err) => console.error(err))
-              .then(() => props.setState(1));
+              .then(() => props.setState(Pages.MainPage));
           }}>Submit</button>
         </p>
         <p>
@@ -71,13 +78,13 @@ const ErrorPage = () => {
 
 function App() {
 
-  const [state, setState] = useState(0);
+  const [state, setState] = useState(Pages.AuthPage);
 
   //depending on the state of the app (set through an enum, the app will display a specific page)
   switch (state) {
-    case 0:
+    case Pages.AuthPage:
       return <AuthPage setState={setState} />;
-    case 1:
+    case Pages.MainPage:
       return <MainPage setState={setState} />;
     default:
       return <ErrorPage />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ const AuthPage = (props: BaseParams) => {
 
 
   return (
-    < div className="App">
+    <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>
@@ -42,7 +42,7 @@ const AuthPage = (props: BaseParams) => {
         <p>
           <input type='text' id="auth-code" placeholder='Paste authentication code here' />
           <button onClick={() => {
-            let code: string = (document.getElementById("auth-code") as HTMLInputElement).value;
+            const code: string = (document.getElementById("auth-code") as HTMLInputElement).value;
             invoke('finalize_auth', { code })
               .catch((err) => console.error(err))
               .then(() => props.setState(Pages.MainPage));


### PR DESCRIPTION
- A method for upserting the template the application uses and storing the new / existing template id for later use in the document (Also contained in a JSON file)
- A complete refactor of the display system to allow for multiple components
- An error handler designed to not crash the program upon errors by handling all invoked backend call errors and pushing them to the frontend for display